### PR TITLE
Fix incorrect CLI help logic

### DIFF
--- a/import_spotify.py
+++ b/import_spotify.py
@@ -129,8 +129,4 @@ def main():
     add_songs_to_playlist(csv_file, playlist_id)
 
 if __name__ == '__main__':
-    # Check if --help or -h is in the arguments
-    if len(sys.argv) > 1 and sys.argv[1] in ['--help', '-h']:
-        parse_arguments()  # This will show help and exit
-    else:
-        main()
+    main()


### PR DESCRIPTION
## Summary
- simplify import script entrypoint so that argparse handles `-h/--help`

## Testing
- `python -m py_compile import_spotify.py`